### PR TITLE
Create a "one-liner" installer and Debug GitHub Workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
 
       - name: SSHd
         run: |
-          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -vvv -b feature/installer -r -- -w
+          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -vvv -b feature/installer -r -- -v -w
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
 
       - name: SSHd
         run: |
-          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -vvv -b feature/installer -r -- -v -w
+          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -vvv -b feature/installer -r -- -v -w -- -g "${{ github.actor }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
 
       - name: SSHd
         run: |
-          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -vvv -b feature/installer -r -- -v -w -- -g "${{ github.actor }}"
+          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -b feature/installer -r -- -w -- -g "${{ github.actor }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
 
       - name: SSHd
         run: |
-          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -b feature/installer -r -- -w -- -g "${{ github.actor }}"
+          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -vvv -b feature/installer -r -i entrypoint.sh -- -v -g "${{ github.actor }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: test
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - feature/*
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: SSHd
+        run: |
+          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -- -b feature/installer -r -- -w
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
 
       - name: SSHd
         run: |
-          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -- -b feature/installer -r -- -w
+          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -b feature/installer -r -- -w
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
 
       - name: SSHd
         run: |
-          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -b feature/installer -r -- -w
+          curl -sSL https://github.com/efrecon/sshd-cloudflared/raw/feature/installer/install.sh | sh -s -- -vvv -b feature/installer -r -- -w
 

--- a/cf-sshd.sh
+++ b/cf-sshd.sh
@@ -134,7 +134,7 @@ fi
 
 if printf %s\\n "$CF_SSHD_IMAGE" | grep -Eq ':latest$'; then
   verbose "Pulling latest image $CF_SSHD_IMAGE"
-  docker image pull -q "$CF_SSHD_IMAGE" >/dev/null
+  docker image pull "$CF_SSHD_IMAGE"
 fi
 
 

--- a/cf-sshd.sh
+++ b/cf-sshd.sh
@@ -134,7 +134,7 @@ fi
 
 if printf %s\\n "$CF_SSHD_IMAGE" | grep -Eq ':latest$'; then
   verbose "Pulling latest image $CF_SSHD_IMAGE"
-  docker image pull "$CF_SSHD_IMAGE"
+  docker image pull -q "$CF_SSHD_IMAGE" >/dev/null
 fi
 
 

--- a/cf-sshd.sh
+++ b/cf-sshd.sh
@@ -142,6 +142,7 @@ fi
 # GitHub search API.
 if [ "$#" = "0" ] && command -v git >/dev/null 2>&1; then
   verbose "No GitHub handle given, will try to guess from git settings"
+  set -x
   handle=;       # Will be the GitHub username, if any
   # Pick user information from gt
   email=$(git config user.email)

--- a/cf-sshd.sh
+++ b/cf-sshd.sh
@@ -141,6 +141,7 @@ fi
 # No parameters, try guessing the github username from git settings using the
 # GitHub search API.
 if [ "$#" = "0" ] && command -v git >/dev/null 2>&1; then
+  verbose "No GitHub handle given, will try to guess from git settings"
   handle=;       # Will be the GitHub username, if any
   # Pick user information from gt
   email=$(git config user.email)

--- a/cf-sshd.sh
+++ b/cf-sshd.sh
@@ -38,6 +38,9 @@ CF_SSHD_PORT=${CF_SSHD_PORT:-""}
 # the container.
 CF_SSHD_AUTOMOUNT=${CF_SSHD_AUTOMOUNT:-".cdk* .aws .npm .local .git .docker"}
 
+# Should we wait until container has ended
+CF_SSHD_WAIT=${CF_SSHD_WAIT:-0}
+
 usage() {
   # This uses the comments behind the options to show the help. Not extremly
   # correct, but effective and simple.
@@ -50,7 +53,7 @@ usage() {
   exit "${1:-0}"
 }
 
-while getopts "e:i:l:p:rvh-" opt; do
+while getopts "e:i:l:p:wrvh-" opt; do
   case "$opt" in
     e) # Name of development environment, e.g. name of host in container and SSHd config. Default: directory name
       CF_SSHD_ENVIRONMENT="$OPTARG";;
@@ -62,6 +65,8 @@ while getopts "e:i:l:p:rvh-" opt; do
       CF_SSHD_IMAGE="$OPTARG";;
     p) # Local port where to make available the SSH daemon. Default: none
       CF_SSHD_PORT="$OPTARG";;
+    w) # Wait until container has ended before exiting
+      CF_SSHD_WAIT=1;;
     -) # End of options, everything after is passed to the entrypoint of the Docker image.
       break;;
     v) # Turn on verbosity, will otherwise log on errors/warnings only
@@ -250,3 +255,8 @@ while ! docker logs "$c" 2>&1 | grep -qE "^${prefix}"; do sleep 0.25; done
 
 verbose "Running in container $c"
 docker logs "$c" 2>&1 | grep -E "^${prefix}" | sed -E "s/^${prefix}//g"
+
+if [ "$CF_SSHD_WAIT" = "1" ]; then
+  verbose "Waiting for container to end..."
+  docker container wait "$c"
+fi

--- a/cf-sshd.sh
+++ b/cf-sshd.sh
@@ -142,11 +142,10 @@ fi
 # GitHub search API.
 if [ "$#" = "0" ] && command -v git >/dev/null 2>&1; then
   verbose "No GitHub handle given, will try to guess from git settings"
-  set -x
   handle=;       # Will be the GitHub username, if any
   # Pick user information from gt
-  email=$(git config user.email)
-  fullname=$(git config user.name)
+  email=$(git config user.email || true)
+  fullname=$(git config user.name || true)
   # Search using the email address, this is often concealed though.
   if [ -n "$email" ]; then
     handle=$( curl --location --silent -G \

--- a/cf-sshd.sh
+++ b/cf-sshd.sh
@@ -223,8 +223,10 @@ fi
 newline=$(printf n\\n|tr n \\n);  # Generates a newline
 for ptn in $CF_SSHD_AUTOMOUNT; do
   while IFS="$newline" read -r path; do
-    verbose "Automounting $path into container"
-    set -- -v "${path}:${path}:rw" "$@"
+    if [ -n "$path" ]; then
+      verbose "Automounting $path into container"
+      set -- -v "${path}:${path}:rw" "$@"
+    fi
   done<<EOF
 $(find "$HOME" -maxdepth 1 -name "$ptn")
 EOF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -175,7 +175,7 @@ ssh-keygen -q -f "${CF_SSHD_SSHDIR}/ssh_host_rsa_key" -N '' -b 4096 -t rsa
 
 # Generate SSHd configuration template when missing.
 if [ -z "$CF_SSHD_TEMPLATE" ] || ! [ -f "$CF_SSHD_TEMPLATE" ]; then
-  warning "No SSHd template found at $CF_SSHD_TEMPLATE, using internal default"
+  warn "No SSHd template found at $CF_SSHD_TEMPLATE, using internal default"
   CF_SSHD_TEMPLATE=$(mktemp)
   cat <<'EOF' > "$CF_SSHD_TEMPLATE"
 LogLevel DEBUG3

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,178 @@
+#!/bin/sh
+
+# Shell sanity. Stop on errors and undefined variables.
+set -eu
+
+# The root location of the github site
+: "${INSTALL_GITHUB:="https://github.com"}"
+
+# Name of this project at GitHub
+: "${INSTALL_PROJECT:="efrecon/sshd-cloudflared"}"
+
+# Name of the cloudflared project at GitHub
+: "${INSTALL_CLOUDFLARED:="cloudflare/cloudflared"}"
+
+# The branch of this project to use for the installation
+: "${INSTALL_BRANCH:="main"}"
+
+# Should we run the installed script? (all options after the -- are blindly
+# passed)
+: "${INSTALL_RUN:=false}"
+
+# Level of verbosity, the higher the more verbose. All messages are sent to the
+# stderr.
+: "${INSTALL_VERBOSE:=0}"
+
+# Where to send logs
+: "${INSTALL_LOG:=2}"
+
+
+usage() {
+  # This uses the comments behind the options to show the help. Not extremly
+  # correct, but effective and simple.
+  echo "install.sh -- Install sshd-cloudflared and cloudflared, run it if requested}" && \
+    grep "[[:space:]].) #" "$0" |
+    sed 's/#//' |
+    sed -r 's/([a-zA-Z-])\)/-\1/'
+  if [ -n "${2:-}" ]; then
+    printf '\nCurrent state:\n'
+    set | grep -E "^${2}_" | sed -E 's/^([A-Z])/  \1/g'
+  fi
+  exit "${1:-0}"
+}
+
+while getopts "rl:vh-" opt; do
+  case "$opt" in
+    r) # Run the installed script
+      INSTALL_RUN=true;;
+    l) # Where to send logs
+      INSTALL_LOG="$OPTARG";;
+    v) # Increase verbosity, will otherwise log on errors/warnings only
+      INSTALL_VERBOSE=$((INSTALL_VERBOSE+1));;
+    h) # Print help and exit
+      usage 0 "INSTALL";;
+    -) # End of options, everything after is passed to the entrypoint of the Docker image.
+      break;;
+    ?)
+      usage 1;;
+  esac
+done
+shift $((OPTIND-1))
+
+# PML: Poor Man's Logging
+_log() {
+  # Capture level and shift it away, rest will be passed blindly to printf
+  _lvl=${1:-LOG}; shift
+  # shellcheck disable=SC2059 # We want to expand the format string
+  printf '[%s] [%s] [%s] %s\n' \
+    "install.sh" \
+    "$_lvl" \
+    "$(date +'%Y%m%d-%H%M%S')" \
+    "$(printf "$@")" \
+    >&"$INSTALL_LOG"
+}
+trace() { if [ "${INSTALL_VERBOSE:-0}" -ge "3" ]; then _log TRC "$@"; fi; }
+debug() { if [ "${INSTALL_VERBOSE:-0}" -ge "2" ]; then _log DBG "$@"; fi; }
+verbose() { if [ "${INSTALL_VERBOSE:-0}" -ge "1" ]; then _log NFO "$@"; fi; }
+info() { if [ "${INSTALL_VERBOSE:-0}" -ge "1" ]; then _log NFO "$@"; fi; }
+warn() { _log WRN "$@"; }
+error() { _log ERR "$@" && exit 1; }
+
+# shellcheck disable=SC2120 # Take none or one argument
+to_lower() {
+  if [ -z "${1:-}" ]; then
+    tr '[:upper:]' '[:lower:]'
+  else
+    printf %s\\n "$1" | to_lower
+  fi
+}
+
+is_true() {
+  case "$(to_lower "${1:-}")" in
+    1 | true | yes | y | on | t) return 0;;
+    *) return 1;;
+  esac
+}
+
+# Check if a command is available. If not, print a warning and return 1.
+check_command() {
+  trace "Checking $1 is an accessible command"
+  if ! command -v "$1" >/dev/null 2>&1; then
+    warn "Command not found: %s" "$1"
+    return 1
+  fi
+}
+
+# Run the command passed as arguments as root, i.e. with sudo if
+# available/necessary. Generate an error if not possible.
+as_root() {
+  if [ "$(id -u)" = 0 ]; then
+    "$@"
+  elif check_command sudo; then
+    verbose "Running elevated command: %s" "$*"
+    sudo "$@"
+  else
+    error "This script requires root privileges"
+  fi
+}
+
+# Download the url passed as the first argument to the destination path passed
+# as a second argument. The destination will be the same as the basename of the
+# URL, in the current directory, if omitted.
+download() {
+  verbose "Downloading $1 to ${2:-$(basename "$1")}"
+  if command -v curl >/dev/null; then
+    curl -sSL -o "${2:-$(basename "$1")}" "$1"
+  elif command -v wget >/dev/null; then
+    wget -q -O "${2:-$(basename "$1")}" "$1"
+  else
+    error "You need curl or wget installed to download files!"
+  fi
+}
+
+install_binary() {
+  as_root download "$1" "${3:-"/usr/local/bin"}/${2:-$(basename "$1")}"
+  as_root chmod +x "${3:-"/usr/local/bin"}/${2:-$(basename "$1")}"
+}
+
+github_releases() {
+  download "${INSTALL_GITHUB%%/}/${1}/releases" - |
+    grep -oE "${1}/releases/tag/v?[0-9]+\.[0-9]+\.[0-9]+" |
+    grep -oE "[0-9]+\.[0-9]+\.[0-9]+" |
+    sed '/-/!{s/$/_/}' |
+    sort -Vr |
+    sed 's/_$//'
+}
+
+install_cloudflared() {
+  latest=$(github_releases "$INSTALL_CLOUDFLARED" | head -n 1)
+  if [ -z "$latest" ]; then
+    error "Could not find a release of cloudflared"
+  fi
+  arch=
+  case "$(uname -m)" in
+    "x86_64")   arch=amd64;;
+    "i686")     arch=386;;
+    "aarch64")  arch=arm64;;
+    "armv7l")   arch=arm;;
+  esac
+  if [ -z "$arch" ]; then
+    error "Unsupported architecture: %s" "$(uname -m)"
+  fi
+  url=${INSTALL_GITHUB%%/}/${INSTALL_CLOUDFLARED%//}/releases/download/${latest}/cloudflared-$(uname -s|to_lower)-${arch}
+  install_binary "$url" cloudflared
+}
+
+
+if ! check_command cloudflared; then
+  install_cloudflared
+fi
+
+if ! check_command cf-sshd.sh; then
+  install_binary "${INSTALL_GITHUB%%/}/${INSTALL_PROJECT%//}/raw/${INSTALL_BRANCH}/cf-sshd.sh"
+fi
+
+if is_true "$INSTALL_RUN"; then
+  verbose "Running cf-sshd.sh"
+  exec cf-sshd.sh "$@"
+fi

--- a/install.sh
+++ b/install.sh
@@ -41,8 +41,10 @@ usage() {
   exit "${1:-0}"
 }
 
-while getopts "rl:vh-" opt; do
+while getopts "b:rl:vh-" opt; do
   case "$opt" in
+    b) # Branch to use for the installation
+      INSTALL_BRANCH="$OPTARG";;
     r) # Run the installed script
       INSTALL_RUN=true;;
     l) # Where to send logs

--- a/install.sh
+++ b/install.sh
@@ -133,8 +133,10 @@ download() {
 }
 
 install_binary() {
-  as_root download "$1" "${3:-"/usr/local/bin"}/${2:-$(basename "$1")}"
-  as_root chmod +x "${3:-"/usr/local/bin"}/${2:-$(basename "$1")}"
+  _bin=$(mktemp)
+  download "$1" "$_bin"
+  chmod +x "$_bin"
+  as_root mv -f "$_bin" "${3:-"/usr/local/bin"}/${2:-$(basename "$1")}"
 }
 
 github_releases() {

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,9 @@ set -eu
 # The branch of this project to use for the installation
 : "${INSTALL_BRANCH:="main"}"
 
+# The name of the script to install and run
+: "${INSTALL_SCRIPT:="cf-sshd.sh"}"
+
 # Should we run the installed script? (all options after the -- are blindly
 # passed)
 : "${INSTALL_RUN:=false}"
@@ -41,10 +44,12 @@ usage() {
   exit "${1:-0}"
 }
 
-while getopts "b:rl:vh-" opt; do
+while getopts "b:i:rl:vh-" opt; do
   case "$opt" in
     b) # Branch to use for the installation
       INSTALL_BRANCH="$OPTARG";;
+    i) # Name of the script to install and run
+      INSTALL_SCRIPT="$OPTARG";;
     r) # Run the installed script
       INSTALL_RUN=true;;
     l) # Where to send logs
@@ -172,8 +177,8 @@ if ! check_command cloudflared; then
   install_cloudflared
 fi
 
-if ! check_command cf-sshd.sh; then
-  install_binary "${INSTALL_GITHUB%%/}/${INSTALL_PROJECT%//}/raw/${INSTALL_BRANCH}/cf-sshd.sh"
+if ! check_command "$INSTALL_SCRIPT"; then
+  install_binary "${INSTALL_GITHUB%%/}/${INSTALL_PROJECT%//}/raw/${INSTALL_BRANCH}/$INSTALL_SCRIPT" "cf-sshd.sh"
 fi
 
 if is_true "$INSTALL_RUN"; then


### PR DESCRIPTION
This creates a "one-liner" installer that will download and install cloudflared and the wrapper script.

Through few modifications to the scripts inside the project, the installer can be used to debug GitHub workflows. Documentation has been amended to highlight this feature and describe how to do.